### PR TITLE
Support >2 channels

### DIFF
--- a/Fmod5Sharp/CodecRebuilders/FmodVorbisRebuilder.cs
+++ b/Fmod5Sharp/CodecRebuilders/FmodVorbisRebuilder.cs
@@ -176,7 +176,7 @@ namespace Fmod5Sharp.CodecRebuilders
             {
                 var packetSize = inputReader.ReadUInt16();
 
-                if (packetSize == 0)
+                if (packetSize == 0 || packetSize == 0xFFFF)
                     break; //EOS
 
                 packetLengths.Add(packetSize);

--- a/Fmod5Sharp/FmodTypes/FmodSampleMetadata.cs
+++ b/Fmod5Sharp/FmodTypes/FmodSampleMetadata.cs
@@ -4,7 +4,8 @@ using Fmod5Sharp.Util;
 
 namespace Fmod5Sharp.FmodTypes
 {
-	public class FmodSampleMetadata : IBinaryReadable
+    //Can be verified against "FMOD::CodecFSB5::decodeSubSoundHeader" in fmod.dll
+    public class FmodSampleMetadata : IBinaryReadable
 	{
 		internal bool HasAnyChunks;
 		internal uint FrequencyId;

--- a/Fmod5Sharp/FmodTypes/FmodSampleMetadata.cs
+++ b/Fmod5Sharp/FmodTypes/FmodSampleMetadata.cs
@@ -1,38 +1,43 @@
-﻿using System.Collections.Generic;
+﻿using Fmod5Sharp.Util;
+using System.Collections.Generic;
 using System.IO;
-using Fmod5Sharp.Util;
 
 namespace Fmod5Sharp.FmodTypes
 {
-	public class FmodSampleMetadata : IBinaryReadable
-	{
-		internal bool HasAnyChunks;
-		internal uint FrequencyId;
-		internal ulong DataOffset;
-		internal List<FmodSampleChunk> Chunks = new();
-		internal int NumChannels;
+    public class FmodSampleMetadata : IBinaryReadable
+    {
+        internal bool HasAnyChunks;
+        internal uint FrequencyId;
+        internal ulong DataOffset;
+        internal List<FmodSampleChunk> Chunks = new();
+        internal int NumChannels;
 
-		public bool IsStereo;
-		public ulong SampleCount;
+        public bool IsStereo;
+        public ulong SampleCount;
 
-		public int Frequency => FsbLoader.Frequencies.TryGetValue(FrequencyId, out var actualFrequency) ? actualFrequency : (int)FrequencyId; //If set by FREQUENCY chunk, id is actual frequency
-		public uint Channels => (uint)NumChannels;
+        public int Frequency => FsbLoader.Frequencies.TryGetValue(FrequencyId, out var actualFrequency) ? actualFrequency : (int)FrequencyId; // If set by FREQUENCY chunk, id is actual frequency
+        public uint Channels => (uint)NumChannels;
 
-		void IBinaryReadable.Read(BinaryReader reader)
-		{
-			var encoded = reader.ReadUInt64();
-			
-			HasAnyChunks = (encoded & 1) == 1; //Bit 0
-			FrequencyId = (uint) encoded.Bits( 1, 4); //Bits 1-4
-			var pow2 = (int) encoded.Bits(5, 2); //Bits 5-6
-			NumChannels = 1 << pow2;
-			if (NumChannels > 2)
-				throw new("> 2 channels not supported");
-			
-			IsStereo = NumChannels == 2;
-			
-			DataOffset = encoded.Bits(7, 27) * 32;
-			SampleCount = encoded.Bits(34, 30);
-		}
-	}
+        void IBinaryReadable.Read(BinaryReader reader)
+        {
+            var sampleMode = reader.ReadUInt64();
+
+            HasAnyChunks = (sampleMode & 1) == 1; // Bit 0
+            FrequencyId = (uint)sampleMode.Bits(1, 4); // Bits 1-4
+
+            int channelBits = (int)sampleMode.Bits(5, 2); // Bits 5-6
+            NumChannels = channelBits switch
+            {
+                0 => 1,
+                1 => 2,
+                2 => 6,
+                3 => 8,
+                _ => throw new("Number of channels not supported"),
+            };
+            IsStereo = NumChannels == 2;
+
+            DataOffset = sampleMode.Bits(7, 27) * 32;
+            SampleCount = sampleMode.Bits(34, 30);
+        }
+    }
 }

--- a/Fmod5Sharp/FmodTypes/FmodSampleMetadata.cs
+++ b/Fmod5Sharp/FmodTypes/FmodSampleMetadata.cs
@@ -1,43 +1,44 @@
-﻿using Fmod5Sharp.Util;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
+using Fmod5Sharp.Util;
 
 namespace Fmod5Sharp.FmodTypes
 {
-    public class FmodSampleMetadata : IBinaryReadable
-    {
-        internal bool HasAnyChunks;
-        internal uint FrequencyId;
-        internal ulong DataOffset;
-        internal List<FmodSampleChunk> Chunks = new();
-        internal int NumChannels;
+	public class FmodSampleMetadata : IBinaryReadable
+	{
+		internal bool HasAnyChunks;
+		internal uint FrequencyId;
+		internal ulong DataOffset;
+		internal List<FmodSampleChunk> Chunks = new();
+		internal int NumChannels;
 
-        public bool IsStereo;
-        public ulong SampleCount;
+		public bool IsStereo;
+		public ulong SampleCount;
 
-        public int Frequency => FsbLoader.Frequencies.TryGetValue(FrequencyId, out var actualFrequency) ? actualFrequency : (int)FrequencyId; // If set by FREQUENCY chunk, id is actual frequency
-        public uint Channels => (uint)NumChannels;
+		public int Frequency => FsbLoader.Frequencies.TryGetValue(FrequencyId, out var actualFrequency) ? actualFrequency : (int)FrequencyId; //If set by FREQUENCY chunk, id is actual frequency
+		public uint Channels => (uint)NumChannels;
 
-        void IBinaryReadable.Read(BinaryReader reader)
-        {
-            var sampleMode = reader.ReadUInt64();
+		void IBinaryReadable.Read(BinaryReader reader)
+		{
+			var encoded = reader.ReadUInt64();
+			
+			HasAnyChunks = (encoded & 1) == 1; //Bit 0
+			FrequencyId = (uint) encoded.Bits( 1, 4); //Bits 1-4
 
-            HasAnyChunks = (sampleMode & 1) == 1; // Bit 0
-            FrequencyId = (uint)sampleMode.Bits(1, 4); // Bits 1-4
-
-            int channelBits = (int)sampleMode.Bits(5, 2); // Bits 5-6
-            NumChannels = channelBits switch
-            {
-                0 => 1,
-                1 => 2,
-                2 => 6,
-                3 => 8,
-                _ => throw new("Number of channels not supported"),
-            };
-            IsStereo = NumChannels == 2;
-
-            DataOffset = sampleMode.Bits(7, 27) * 32;
-            SampleCount = sampleMode.Bits(34, 30);
-        }
-    }
+			int channelBits = (int)encoded.Bits(5, 2); //Bits 5-6
+			NumChannels = channelBits switch
+			{
+				0 => 1,
+				1 => 2,
+				2 => 6,
+				3 => 8,
+				_ => throw new("Number of channels not supported")
+			};
+			
+			IsStereo = NumChannels == 2;
+			
+			DataOffset = encoded.Bits(7, 27) * 32;
+			SampleCount = encoded.Bits(34, 30);
+		}
+	}
 }

--- a/Fmod5Sharp/FmodTypes/FmodSampleMetadata.cs
+++ b/Fmod5Sharp/FmodTypes/FmodSampleMetadata.cs
@@ -32,7 +32,7 @@ namespace Fmod5Sharp.FmodTypes
 				1 => 2,
 				2 => 6,
 				3 => 8,
-				_ => throw new("Number of channels not supported")
+				_ => 0
 			};
 			
 			IsStereo = NumChannels == 2;

--- a/Fmod5Sharp/FsbLoader.cs
+++ b/Fmod5Sharp/FsbLoader.cs
@@ -10,9 +10,10 @@ namespace Fmod5Sharp
     {
         internal static readonly Dictionary<uint, int> Frequencies = new()
         {
-            { 1, 8000 },
+            { 0, 4_000 },
+            { 1, 8_000 },
             { 2, 11_000 },
-            { 3, 11_025 },
+            { 3, 12_000 },
             { 4, 16_000 },
             { 5, 22_050 },
             { 6, 24_000 },


### PR DESCRIPTION
Number of channels was being read and then written incorrectly into packet info (for e.x. 4 instead of 6), resulting in malformed audio output. This fixes Vorbis rebuilder.

I can't tell about other formats though as I don't have any to test nor do I need them. I would appreciate if this could be merged as I need it in a different project. In case this breaks other formats somehow I would suggest to only skip samples with >2 channels in these cases instead of throwing completely