### PR TITLE
Support loading large FSB5 chunks

### DIFF
--- a/Fmod5Sharp/FsbLoader.cs
+++ b/Fmod5Sharp/FsbLoader.cs
@@ -36,6 +36,8 @@ namespace Fmod5Sharp
                 return null;
             }
 
+            long dataStartOffset = header.SizeOfThisHeader + header.SizeOfNameTable + header.SizeOfSampleHeaders;
+
             List<FmodSample> samples = new(header.Samples.Count);
             for (var i = 0; i < header.Samples.Count; i++)
             {
@@ -50,7 +52,7 @@ namespace Fmod5Sharp
                 }
 
                 byte[] sampleData = new byte[lastByteOfSample - firstByteOfSample];
-                stream.Position = firstByteOfSample;
+                stream.Position = dataStartOffset + firstByteOfSample;
                 stream.Read(sampleData, 0, sampleData.Length);
 
                 var sample = new FmodSample(sampleMetadata, sampleData);

--- a/Fmod5Sharp/Util/Extensions.cs
+++ b/Fmod5Sharp/Util/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
@@ -41,13 +42,14 @@ namespace Fmod5Sharp.Util
             return (raw & mask) >> lowestBit;
         }
 
-        internal static string ReadNullTerminatedString(this byte[] bytes, int startOffset)
+        internal static string ReadNullTerminatedString(this Stream stream)
         {
-            var strLen = bytes.AsSpan(startOffset).IndexOf((byte)0);
-            if (strLen == -1)
-                throw new("Could not find null terminator");
-            
-            return Encoding.UTF8.GetString(bytes, startOffset, strLen);
+            List<byte> bytes = new(16);
+            int b;
+            while ((b = stream.ReadByte()) > 0)
+                bytes.Add((byte)b);
+
+            return Encoding.UTF8.GetString(bytes.ToArray());
         }
     }
 }


### PR DESCRIPTION
I've encountered FSB5 chunk that is larger than `int.MaxValue`, changing internal loading to a stream supports loading such a large files. I have kept old method so it can still be loaded via byte array as previously or as a stream