### PR TITLE
Fix generating audio files that are a teeny tiny bit longer than the original

### DIFF
--- a/Fmod5Sharp.Tests/Fmod5Sharp.Tests.csproj
+++ b/Fmod5Sharp.Tests/Fmod5Sharp.Tests.csproj
@@ -17,6 +17,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="NVorbis" Version="0.10.5" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Fmod5Sharp.Tests/Fmod5Sharp.Tests.csproj
+++ b/Fmod5Sharp.Tests/Fmod5Sharp.Tests.csproj
@@ -17,6 +17,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="NAudio.Core" Version="2.1.0"/>
         <PackageReference Include="NVorbis" Version="0.10.5" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Fmod5Sharp.Tests/Fmod5SharpPcmTests.cs
+++ b/Fmod5Sharp.Tests/Fmod5SharpPcmTests.cs
@@ -1,5 +1,7 @@
 ﻿using Fmod5Sharp.CodecRebuilders;
 using Fmod5Sharp.FmodTypes;
+using NAudio.Wave;
+using System.IO;
 using Xunit;
 
 namespace Fmod5Sharp.Tests
@@ -23,9 +25,11 @@ namespace Fmod5Sharp.Tests
 
             var fsb = FsbLoader.LoadFsbFromByteArray(rawData);
 
-            var wavFile = FmodPcmRebuilder.Rebuild(fsb.Samples[0], fsb.Header.AudioType);
-            
-            Assert.NotEmpty(wavFile);
+            var sample = fsb.Samples[0];
+
+            var wavFile = FmodPcmRebuilder.Rebuild(sample, fsb.Header.AudioType);
+
+            Assert.Equal(sample.Metadata.SampleCount, new WaveFileReader(new MemoryStream(wavFile)).SampleCount);
         }
     }
 }

--- a/Fmod5Sharp.Tests/Fmod5SharpVorbisTests.cs
+++ b/Fmod5Sharp.Tests/Fmod5SharpVorbisTests.cs
@@ -1,4 +1,7 @@
 using Fmod5Sharp.CodecRebuilders;
+using Fmod5Sharp.FmodTypes;
+using NVorbis;
+using System.IO;
 using Xunit;
 
 namespace Fmod5Sharp.Tests
@@ -27,9 +30,7 @@ namespace Fmod5Sharp.Tests
             
             var oggBytes = FmodVorbisRebuilder.RebuildOggFile(sample);
             
-            Assert.NotEmpty(oggBytes);
-            
-            //Cannot assert on length output bytes because it changes with the version of libvorbis you use.
+            CheckSampleCount(sample, oggBytes);
         }
 
         [Fact]
@@ -43,7 +44,7 @@ namespace Fmod5Sharp.Tests
             
             var oggBytes = FmodVorbisRebuilder.RebuildOggFile(sample);
             
-            Assert.NotEmpty(oggBytes);
+            CheckSampleCount(sample, oggBytes);
         }
 
         [Fact]
@@ -57,7 +58,7 @@ namespace Fmod5Sharp.Tests
             
             var oggBytes = FmodVorbisRebuilder.RebuildOggFile(sample);
             
-            Assert.NotEmpty(oggBytes);
+            CheckSampleCount(sample, oggBytes);
         }
 
         [Fact]
@@ -71,7 +72,12 @@ namespace Fmod5Sharp.Tests
             
             var oggBytes = FmodVorbisRebuilder.RebuildOggFile(sample);
             
-            Assert.NotEmpty(oggBytes);
+            CheckSampleCount(sample, oggBytes);
+        }
+
+        private bool CheckSampleCount(FmodSample sample, byte[] oggBytes)
+        {
+            Assert.Equal(sample.Metadata.SampleCount, new VorbisReader(new MemoryStream(oggBytes)).TotalSamples);
         }
     }
 }

--- a/Fmod5Sharp/CodecRebuilders/FmodPcmRebuilder.cs
+++ b/Fmod5Sharp/CodecRebuilders/FmodPcmRebuilder.cs
@@ -1,6 +1,6 @@
-﻿using System.IO;
-using Fmod5Sharp.FmodTypes;
+﻿using Fmod5Sharp.FmodTypes;
 using NAudio.Wave;
+using System.IO;
 
 namespace Fmod5Sharp.CodecRebuilders
 {
@@ -28,7 +28,7 @@ namespace Fmod5Sharp.CodecRebuilders
             using var stream = new MemoryStream();
             using var writer = new WaveFileWriter(stream, format);
             
-            writer.Write(sample.SampleBytes, 0, sample.SampleBytes.Length);
+            writer.Write(sample.SampleBytes, 0, numChannels * width * (int) sample.Metadata.SampleCount);
 
             return stream.GetBuffer();
         }

--- a/Fmod5Sharp/CodecRebuilders/FmodVorbisRebuilder.cs
+++ b/Fmod5Sharp/CodecRebuilders/FmodVorbisRebuilder.cs
@@ -60,7 +60,7 @@ namespace Fmod5Sharp.CodecRebuilders
             
             oggStream.FlushAndCopyTo(outputStream, true);
 
-            CopySampleData(vorbisData, sample.SampleBytes, oggStream, outputStream);
+            CopySampleData(vorbisData, sample.Metadata.SampleCount, sample.SampleBytes, oggStream, outputStream);
 
             return outputStream.ToArray();
         }
@@ -130,7 +130,7 @@ namespace Fmod5Sharp.CodecRebuilders
             return new(oggMs.ToArray(), false, 0, 1);
         }
 
-        private static void CopySampleData(FmodVorbisData vorbisData, byte[] sampleBytes, OggStream oggStream, Stream outputStream)
+        private static void CopySampleData(FmodVorbisData vorbisData, uint sampleCount, byte[] sampleBytes, OggStream oggStream, Stream outputStream)
         {
             using var inputStream = new MemoryStream(sampleBytes);
             using var inputReader = new BinaryReader(inputStream);
@@ -138,8 +138,8 @@ namespace Fmod5Sharp.CodecRebuilders
             ReadSamplePackets(inputReader, out var packetLength, out var packets);
 
             var packetNum = 1;
-            var granulePos = 0;
-            var previousBlockSize = 0;
+            uint granulePos = 0;
+            uint previousBlockSize = 0;
             
             var finalPacketNum = packetLength.Count - 1;
             
@@ -158,16 +158,24 @@ namespace Fmod5Sharp.CodecRebuilders
                 else
                     granulePos += (blockSize + previousBlockSize) / 4;
                 
+                //Make sure to end the stream once we reach the sample count in the metadata.
+                if (granulePos > sampleCount)
+                    granulePos = sampleCount;
+
                 //Set previous block size
                 previousBlockSize = blockSize;
 
                 //Write the packet to the stream
-                oggStream.PacketIn(new(packet, isLast, granulePos,  packetNum));
+                oggStream.PacketIn(new(packet, isLast, (int) granulePos, packetNum));
                 oggStream.FlushAndCopyTo(outputStream, isLast);
+
+                //Early end to the stream if this is going past the sample count in the metadata.
+                if (granulePos == sampleCount)
+                    break;
             }
         }
 
-        private static void ReadSamplePackets(BinaryReader inputReader, out List<int> packetLengths, out List<byte[]> packets)
+        private static void ReadSamplePackets(BinaryReader inputReader, out List<ushort> packetLengths, out List<byte[]> packets)
         {
             packetLengths = new();
             packets = new();

--- a/Fmod5Sharp/FmodTypes/FmodSampleMetadata.cs
+++ b/Fmod5Sharp/FmodTypes/FmodSampleMetadata.cs
@@ -8,12 +8,12 @@ namespace Fmod5Sharp.FmodTypes
 	{
 		internal bool HasAnyChunks;
 		internal uint FrequencyId;
-		internal ulong DataOffset;
+		internal uint DataOffset;
 		internal List<FmodSampleChunk> Chunks = new();
 		internal int NumChannels;
 
 		public bool IsStereo;
-		public ulong SampleCount;
+		public uint SampleCount;
 
 		public int Frequency => FsbLoader.Frequencies.TryGetValue(FrequencyId, out var actualFrequency) ? actualFrequency : (int)FrequencyId; //If set by FREQUENCY chunk, id is actual frequency
 		public uint Channels => (uint)NumChannels;
@@ -31,8 +31,8 @@ namespace Fmod5Sharp.FmodTypes
 			
 			IsStereo = NumChannels == 2;
 			
-			DataOffset = encoded.Bits(7, 27) * 32;
-			SampleCount = encoded.Bits(34, 30);
+			DataOffset = (uint) encoded.Bits(7, 27) * 32;
+			SampleCount = (uint) encoded.Bits(34, 30);
 		}
 	}
 }

--- a/Fmod5Sharp/Util/FmodVorbisData.cs
+++ b/Fmod5Sharp/Util/FmodVorbisData.cs
@@ -59,7 +59,7 @@ internal class FmodVorbisData
         }).ToArray();
     }
 
-    public int GetPacketBlockSize(byte[] packetBytes)
+    public uint GetPacketBlockSize(byte[] packetBytes)
     {
         var bitStream = new BitStream(packetBytes);
 


### PR DESCRIPTION
I'm using AssetRipper on a game where the precise audio file length is really important. Turns out the SampleCount field in the metadata is significant, and if you don't take it into account the rebuilt audio file will usually be a few milliseconds too long. Traced the problem back to Fmod5Sharp, so here is a fix.